### PR TITLE
feat: data_path argument in construction of BenchmarkSet allows for overriding local config data path

### DIFF
--- a/yahpo_gym/yahpo_gym/benchmark_set.py
+++ b/yahpo_gym/yahpo_gym/benchmark_set.py
@@ -24,6 +24,7 @@ class BenchmarkSet:
         multithread: bool = True,
         check: bool = True,
         noisy: bool = False,
+        data_path = None,
     ):
         """
         Interface for a benchmark scenario.
@@ -37,7 +38,7 @@ class BenchmarkSet:
             (Optional) A key for `ConfigDict` pertaining to a valid instance (e.g. `3945`).
             See `BenchmarkSet(<key>).instances` for a list of available instances.
         active_session: bool
-            Should the benchmark run in an active `onnxruntime.InferenceSession`? Initialized to `Trtue`.
+            Should the benchmark run in an active `onnxruntime.InferenceSession`? Initialized to `True`.
         session: onnx.Session
             A ONNX session to use for inference. Overwrite `active_session` and sets the provided `onnxruntime.InferenceSession` as the active session.
             Initialized to `None`.
@@ -49,10 +50,14 @@ class BenchmarkSet:
             Should input to objective_function be checked for validity? Initialized to `True`, but can be disabled for speedups.
         noisy: bool
             Use stochastic surrogate models? Initialized to `False`.
+        data_path: str
+            Optional path to the data directory. If not provided, the default data path as indicated by the local config is used.
         """
 
         assert scenario is not None, "Please provide a valid scenario."
         self.config = cfg(scenario)
+        if data_path is not None:
+            self.config.config["basedir"] = data_path  # override the default path
         self.encoding = self._get_encoding()
         self.config_space = self._get_config_space()
         self.active_session = active_session


### PR DESCRIPTION
E.g.

```
from yahpo_gym import benchmark_set
import yahpo_gym.benchmarks.lcbench

bench = benchmark_set.BenchmarkSet("lcbench", data_path = tmp_dir)
```

where `tmp_dir` is a temporary directory similar in structure as the usual `yahpo_data` data directory