### PR TITLE
update with pyproject.toml, start ruff, isort, black

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: |
         cd yahpo_gym

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         cd yahpo_gym

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10
     - name: Install dependencies

--- a/.github/workflows/unittests_gym_py.yml
+++ b/.github/workflows/unittests_gym_py.yml
@@ -5,10 +5,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: r-lib/actions/setup-r@v2
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10
     - name: Clone required data
@@ -18,6 +18,7 @@ jobs:
     - name: Prepare [python]
       run: |
         cd ~/work/yahpo_gym/yahpo_gym/yahpo_gym
+        pip install --upgrade pip
         pip install -e .[test]
         printf "data_path: ~/work/yahpo_data\n" >> ~/.config/yahpo_gym
     - name: Run yahpo_gym tests [python]

--- a/.github/workflows/unittests_gym_py.yml
+++ b/.github/workflows/unittests_gym_py.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Clone required data
       run: |
         cd ~/work

--- a/.github/workflows/unittests_gym_py.yml
+++ b/.github/workflows/unittests_gym_py.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Clone required data
       run: |
         cd ~/work

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### What is YAHPO Gym?
 
-**YAHPO Gym** (Yet Another Hyperparameter Optimization Gym) is a collection of interesting problem sets for benchmark hyperparameter optimization / black-box optimization methods described in [this paper](https://arxiv.org/abs/2109.03670).
+**YAHPO Gym** (Yet Another Hyperparameter Optimization Gym) is a collection of interesting problem sets for benchmark hyperparameter optimization / black-box optimization methods described in [this paper](https://proceedings.mlr.press/v188/pfisterer22a.html).
 The underlying software with additional documentation and background can be found [here](https://github.com/slds-lmu/yahpo_gym/tree/main/yahpo_gym).
 See the [module Documentation](https://slds-lmu.github.io/yahpo_gym/) for more info.
 
@@ -29,7 +29,7 @@ We also maintain a list of [frequently asked questions](https://slds-lmu.github.
 
 **NEWS:**
 
-- The [paper](https://arxiv.org/abs/2109.03670) accompanying `YAHPO Gym` was accepted at the 1st International Conference on Automated Machine Learning!
+- The [paper](https://proceedings.mlr.press/v188/pfisterer22a.html) accompanying `YAHPO Gym` was accepted at the 1st International Conference on Automated Machine Learning!
 - YAHPO (Python) can now be installed via `pip install yahpo-gym`
 - YAHPO is now available in [HPOBench](https://github.com/automl/HPOBench/)
 - We are working on integrating YAHPO Gym with [syne-tune](https://github.com/awslabs/syne-tune) for asynchronous benchmarking!

--- a/scripts/yahpo.py
+++ b/scripts/yahpo.py
@@ -1,26 +1,26 @@
 from yahpo_gym import benchmark_set
-import yahpo_gym.benchmarks.lcbench
 import argparse
-import typing
 
 
 class ParseKwargs(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, dict())
         for value in values:
-            key, value = value.split('=')
+            key, value = value.split("=")
             getattr(namespace, self.dest)[key] = value
 
-import argparse
+
 parser = argparse.ArgumentParser()
-parser.add_argument('-b', '--benchmark', type=str, required=False, default="lcbench")
-parser.add_argument('-i', '--instance', type=str, required=False, default="3945")
-parser.add_argument('-k', '--kwargs', nargs='*', action=ParseKwargs, default=None)
+parser.add_argument("-b", "--benchmark", type=str, required=False, default="lcbench")
+parser.add_argument("-i", "--instance", type=str, required=False, default="3945")
+parser.add_argument("-k", "--kwargs", nargs="*", action=ParseKwargs, default=None)
 args = parser.parse_args()
+
 
 def sample_random(bench):
     return bench.get_opt_space().sample_configuration(1).get_dictionary()
-    
+
+
 def eval(args):
     bench = benchmark_set.BenchmarkSet(args.benchmark)
     bench.set_instance(args.instance)
@@ -28,6 +28,7 @@ def eval(args):
         args.kwargs = sample_random(bench)
     ys = bench.objective_function(args.kwargs)
     return ys
-    
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     print(eval(args))

--- a/yahpo_gym/docs/source/getting_started.rst
+++ b/yahpo_gym/docs/source/getting_started.rst
@@ -6,7 +6,13 @@ Getting Started
 Installation (Python)
 =======================
 
-`YAHPO Gym` can be installed directly from GitHub using `pip`:
+`YAHPO Gym` can be installed using `pip`:
+
+.. code-block:: bash
+
+    pip install yahpo-gym
+
+or the latest version directly from GitHub:
 
 .. code-block:: bash
 

--- a/yahpo_gym/pyproject.toml
+++ b/yahpo_gym/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yahpo-gym"
-dynamic = ["version"]
+dynamic = ["version", "license"]
 description = "Inference module for the YAHPO Gym"
 readme = "README.md"
 authors = [
@@ -25,15 +25,27 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+requires-python = ">=3.8"
 dependencies = [
     "onnxruntime>=1.10.0", 
     "pyyaml", 
     "configspace<=0.6.1", 
     "pandas"
 ]
+[project.optional-dependencies]
+test = ["pytest>=4.6", "mypy", "pre-commit", "pytest-cov"]
+docs = [
+    "sphinx",
+    "sphinx-gallery",
+    "sphinx_bootstrap_theme",
+    "numpydoc",
+    "pandas",
+]
 
 [project.urls]
-Homepage = "https://github.com/slds-lmu/yahpo_gym"
+repository = "https://github.com/slds-lmu/yahpo_gym"
+homepage = "https://slds-lmu.github.io/yahpo_gym/"
+documentation = "https://slds-lmu.github.io/yahpo_gym/"
 
 
 [tool.ruff]

--- a/yahpo_gym/pyproject.toml
+++ b/yahpo_gym/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yahpo-gym"
+dynamic = ["version"]
+description = "Inference module for the YAHPO Gym"
+readme = "README.md"
+authors = [
+    { name = "Florian Pfisterer" },
+    { name = "Lennart Schneider" },
+]
+keywords = [
+    "module",
+    "inference",
+    "yahpo",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "onnxruntime>=1.10.0", 
+    "pyyaml", 
+    "configspace<=0.6.1", 
+    "pandas"
+]
+
+[project.urls]
+Homepage = "https://github.com/slds-lmu/yahpo_gym"
+
+
+[tool.ruff]
+line-length = 200
+include = ["pyproject.toml", "yahpo_gym/*.py"]
+indent-width = 4
+target-version = "py310"
+fix = true
+unsafe-fixes = true
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.mypy]
+check_untyped_defs = true
+ignore_missing_imports = true

--- a/yahpo_gym/setup.py
+++ b/yahpo_gym/setup.py
@@ -41,6 +41,4 @@ setup(
         ],
     },
     keywords=["module", "inference", "yahpo"],
-    url="https://github.com/slds-lmu/yahpo_gym",
-    classifiers=["Development Status :: 3 - Alpha"],
 )

--- a/yahpo_gym/setup.py
+++ b/yahpo_gym/setup.py
@@ -40,7 +40,7 @@ setup(
             "pandas",
         ],
     },
-    keywords=["module", "train", "yahpo"],
+    keywords=["module", "inference", "yahpo"],
     url="https://github.com/slds-lmu/yahpo_gym",
     classifiers=["Development Status :: 3 - Alpha"],
 )

--- a/yahpo_gym/yahpo_gym/__init__.py
+++ b/yahpo_gym/yahpo_gym/__init__.py
@@ -1,6 +1,6 @@
 from .about import __version__
 from .local_config import local_config
 from .benchmark_set import BenchmarkSet
-from .benchmarks import *
+from .benchmarks import lcbench, nb301, rbv2, iaml, fair
 from .configuration import list_scenarios
 from .get_suite import get_suite

--- a/yahpo_gym/yahpo_gym/__init__.py
+++ b/yahpo_gym/yahpo_gym/__init__.py
@@ -1,6 +1,0 @@
-from .about import __version__
-from .local_config import local_config
-from .benchmark_set import BenchmarkSet
-from .benchmarks import lcbench, nb301, rbv2, iaml, fair
-from .configuration import list_scenarios
-from .get_suite import get_suite

--- a/yahpo_gym/yahpo_gym/benchmark_set.py
+++ b/yahpo_gym/yahpo_gym/benchmark_set.py
@@ -1,33 +1,34 @@
-from yahpo_gym.configuration import cfg
-import onnxruntime as rt
-import time
-import json
 import copy
+import json
 import os
-
+import time
 from pathlib import Path
-from typing import Union, Dict, List
-import numpy as np
-from ConfigSpace.read_and_write import json as CS_json
+from typing import Dict, List, Union
+
 import ConfigSpace as CS
 import ConfigSpace.hyperparameters as CSH
+import numpy as np
+import onnxruntime as rt
 import pandas as pd
+from ConfigSpace.read_and_write import json as CS_json
+
+from yahpo_gym.configuration import cfg
 
 
 class BenchmarkSet:
     def __init__(
         self,
-        scenario: str = None,
-        instance: str = None,
+        scenario: str | None = None,
+        instance: str | None = None,
         active_session: bool = True,
-        session: Union[rt.InferenceSession, None] = None,
+        session: rt.InferenceSession | None = None,
         multithread: bool = True,
         check: bool = True,
         noisy: bool = False,
     ):
         """
         Interface for a benchmark scenario.
-        Initialized with a valid key for a valid scenario and optinally an `onnxruntime.InferenceSession`.
+        Initialized with a valid key for a valid scenario and optionally an `onnxruntime.InferenceSession`.
 
         Parameters
         ----------
@@ -37,7 +38,7 @@ class BenchmarkSet:
             (Optional) A key for `ConfigDict` pertaining to a valid instance (e.g. `3945`).
             See `BenchmarkSet(<key>).instances` for a list of available instances.
         active_session: bool
-            Should the benchmark run in an active `onnxruntime.InferenceSession`? Initialized to `Trtue`.
+            Should the benchmark run in an active `onnxruntime.InferenceSession`? Initialized to `True`.
         session: onnx.Session
             A ONNX session to use for inference. Overwrite `active_session` and sets the provided `onnxruntime.InferenceSession` as the active session.
             Initialized to `None`.
@@ -77,7 +78,7 @@ class BenchmarkSet:
     def objective_function(
         self,
         configuration: Union[Dict, List[Dict]],
-        seed: int = None,
+        seed: int | None = None,
         logging: bool = False,
         multithread: bool = True,
     ):
@@ -145,7 +146,7 @@ class BenchmarkSet:
     def objective_function_timed(
         self,
         configuration: Union[Dict, List[Dict]],
-        seed: int = None,
+        seed: int | None = None,
         logging: bool = False,
         multithread: bool = True,
     ):
@@ -300,7 +301,9 @@ class BenchmarkSet:
             if not multithread:
                 options.inter_op_num_threads = 1
                 options.intra_op_num_threads = 1
-            self.session = rt.InferenceSession(model_path, sess_options=options, providers=["CPUExecutionProvider"])
+            self.session = rt.InferenceSession(
+                model_path, sess_options=options, providers=["CPUExecutionProvider"]
+            )
 
     @property
     def instances(self):
@@ -480,7 +483,6 @@ class BenchmarkSet:
 
 if __name__ == "__main__":
     from yahpo_gym import benchmark_set
-    import yahpo_gym.benchmarks.lcbench
 
     bench = benchmark_set.BenchmarkSet("iaml_super")
     bench.instances

--- a/yahpo_gym/yahpo_gym/benchmarks/__init__.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/__init__.py
@@ -1,1 +1,1 @@
-from yahpo_gym.benchmarks import lcbench, nb301, rbv2, iaml, fair
+from yahpo_gym.benchmarks import lcbench, nb301, rbv2, iaml, fair  # noqa: F401

--- a/yahpo_gym/yahpo_gym/benchmarks/fair.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/fair.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 # Default dict, holds for all 'fair_' benchmarks
 # Note fpp (Calders-Wevers gap) exlcuded for now

--- a/yahpo_gym/yahpo_gym/benchmarks/fcnet.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/fcnet.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 _fcnet_dict = {
     "config_id": "fcnet",

--- a/yahpo_gym/yahpo_gym/benchmarks/iaml.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/iaml.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 # Default dict, holds for all "iaml_" benchmarks
 _iaml_dict = {

--- a/yahpo_gym/yahpo_gym/benchmarks/lcbench.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/lcbench.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 _lcbench_dict = {
     "config_id": "lcbench",
@@ -11,9 +11,9 @@ _lcbench_dict = {
         "test_balanced_accuracy",
         "time",
         "time_increase",
-        #"model_parameters",
+        # "model_parameters",
     ],
-    #"y_minimize": [False, True, False, False, True, False, True, True, True],
+    # "y_minimize": [False, True, False, False, True, False, True, True, True],
     "y_minimize": [False, True, False, False, True, False, True, True],
     "cont_names": [
         "epoch",

--- a/yahpo_gym/yahpo_gym/benchmarks/nb301.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/nb301.py
@@ -1,11 +1,11 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 _nb301_dict = {
     "config_id": "nb301",
     "model": "model_v2.onnx",
-    #"y_names": ["val_accuracy", "val_cross_entropy", "runtime", "runtime_increase", "model_parameters"],
+    # "y_names": ["val_accuracy", "val_cross_entropy", "runtime", "runtime_increase", "model_parameters"],
     "y_names": ["val_accuracy", "val_cross_entropy", "runtime", "runtime_increase"],
-    #"y_minimize": [False, True, True, True, True],
+    # "y_minimize": [False, True, True, True, True],
     "y_minimize": [False, True, True, True],
     "cont_names": ["epoch"],
     "cat_names": [

--- a/yahpo_gym/yahpo_gym/benchmarks/rbv2.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/rbv2.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 # Default dict, holds for all 'rbv2_' benchmarks
 _rbv2_dict = {

--- a/yahpo_gym/yahpo_gym/benchmarks/taskset.py
+++ b/yahpo_gym/yahpo_gym/benchmarks/taskset.py
@@ -1,4 +1,4 @@
-from yahpo_gym.configuration import config_dict, cfg
+from yahpo_gym.configuration import config_dict
 
 _task_set_dict = {
     "config_id": "task_set",

--- a/yahpo_gym/yahpo_gym/configuration.py
+++ b/yahpo_gym/yahpo_gym/configuration.py
@@ -1,8 +1,8 @@
-import pandas as pd
-import yahpo_gym
-from yahpo_gym.local_config import local_config
-from pathlib import Path
 from typing import Dict
+
+import pandas as pd
+
+from yahpo_gym.local_config import local_config
 
 
 class Configuration:
@@ -164,9 +164,9 @@ class ConfigDict:
         return out
 
 
-def cfg(key: str = None, **kwargs):
+def cfg(key: str|None=None, **kwargs):
     """
-    Shorthand acces to 'ConfigDict'.
+    Shorthand access to 'ConfigDict'.
 
     Parameters
     ----------

--- a/yahpo_gym/yahpo_gym/local_config.py
+++ b/yahpo_gym/yahpo_gym/local_config.py
@@ -1,16 +1,16 @@
 from pathlib import Path
-from typing import Optional
 import os
 import yaml
 
-class LocalConfiguration():
-    def __init__(self, settings_path: str =None):
+
+class LocalConfiguration:
+    def __init__(self, settings_path: str = None):
         """
         Interface for setting up a local configuration.
         This reads from and writes to a configuration file in the YAML format,
         allowing to store paths to the underlying data and models required for
         inference on the fitted surrogates.
-        
+
 
         Parameters
         ----------
@@ -18,20 +18,20 @@ class LocalConfiguration():
             Path to the local configuration file.
             The default is "~/.config/yahpo_gym".
         """
-        if settings_path is None: 
-            if 'YAHPO_LOCAL_CONFIG' in os.environ:
-                settings_path = os.environ['YAHPO_LOCAL_CONFIG']
-            else: 
+        if settings_path is None:
+            if "YAHPO_LOCAL_CONFIG" in os.environ:
+                settings_path = os.environ["YAHPO_LOCAL_CONFIG"]
+            else:
                 settings_path = "~/.config/yahpo_gym"
         self.settings_path = Path(settings_path).expanduser().absolute()
         self._config = None
-    
+
     def init_config(self, data_path: str = ""):
         """
         Initialize a new local configuration.
 
         This writes a local configuration file to the specified 'settings_path'.
-        The 
+        The
         It is currently used to globally store the following information
         'data_path': A path to the metadata required for inference.
 
@@ -41,8 +41,8 @@ class LocalConfiguration():
             Path to the directory where surrogate models and metadata are saved.
         """
         os.makedirs(os.path.dirname(self.settings_path), exist_ok=True)
-        config = {'data_path': str(data_path)}
-        with self.settings_path.open('w', encoding='utf-8') as fh:
+        config = {"data_path": str(data_path)}
+        with self.settings_path.open("w", encoding="utf-8") as fh:
             yaml.dump(config, fh)
         return None
 
@@ -56,20 +56,22 @@ class LocalConfiguration():
             Path to the directory where surrogate models and metadata are saved.
         """
         config = self.config
-        config.update({'data_path': str(data_path)})
-        
-        with self.settings_path.open('w', encoding='utf-8') as fh:
+        config.update({"data_path": str(data_path)})
+
+        with self.settings_path.open("w", encoding="utf-8") as fh:
             yaml.dump(config, fh)
 
     def _load_config(self):
-        config = {"data_path":""}
+        config = {"data_path": ""}
         try:
-            with self.settings_path.open('r') as fh:
+            with self.settings_path.open("r") as fh:
                 config = yaml.load(fh, Loader=yaml.FullLoader)
         except yaml.parser.ParserError:
             raise yaml.parser.ParserError("Could not load config! (Invalid YAML?)")
         except:
-            raise Exception("Could not load local_config! Please run LocalConfiguration.init_config() and restart.")
+            raise Exception(
+                "Could not load local_config! Please run LocalConfiguration.init_config() and restart."
+            )
         return config
 
     @property
@@ -79,14 +81,15 @@ class LocalConfiguration():
         """
         if self._config is None:
             self._config = self._load_config()
-        return(self._config)
+        return self._config
 
     @property
     def data_path(self):
         """
         Path where metadata and surrogate models for inference are stored.
         """
-        return Path(self.config.get('data_path')).expanduser().absolute()
+        return Path(self.config.get("data_path")).expanduser().absolute()
+
 
 local_config = LocalConfiguration()
-__all__ = ['local_config', 'LocalConfiguration']
+__all__ = ["local_config", "LocalConfiguration"]

--- a/yahpo_train/notebooks/attic/tune_ff.py
+++ b/yahpo_train/notebooks/attic/tune_ff.py
@@ -1,10 +1,7 @@
 import argparse
-from functools import partial
 
 import wandb
 from fastai.callback.wandb import *
-from yahpo_gym import benchmark_set
-from yahpo_gym.benchmarks import fcnet, iaml, lcbench, nasbench_301, rbv2, taskset
 from yahpo_gym.configuration import cfg
 
 from yahpo_train.cont_scalers import *
@@ -143,7 +140,6 @@ def tune_config(key, name, tfms_fixed={}, trials=1000, walltime=86400, **kwargs)
 
     import optuna
     from optuna.integration import FastAIPruningCallback
-    from optuna.visualization import plot_optimization_history
 
     if trials == 0:
         trials = None

--- a/yahpo_train/pyproject.toml
+++ b/yahpo_train/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yahpo-train"
-dynamic = ["version"]
+dynamic = ["version", "license"]
 description = "Train surrogate models for the YAHPO Gym"
 readme = "README.md"
 authors = [
@@ -25,6 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+requires-python = ">=3.8"
 dependencies = [
     "fastai",
     "numpy",
@@ -38,7 +39,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/slds-lmu/yahpo_gym"
+repository = "https://github.com/slds-lmu/yahpo_gym"
+homepage = "https://slds-lmu.github.io/yahpo_gym/"
+documentation = "https://slds-lmu.github.io/yahpo_gym/"
 
 [tool.ruff]
 line-length = 200

--- a/yahpo_train/pyproject.toml
+++ b/yahpo_train/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yahpo-train"
+dynamic = ["version"]
+description = "Train surrogate models for the YAHPO Gym"
+readme = "README.md"
+authors = [
+    { name = "Florian Pfisterer" },
+    { name = "Lennart Schneider" },
+]
+keywords = [
+    "module",
+    "train",
+    "yahpo",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "fastai",
+    "numpy",
+    "onnx>=1.14.0",
+    "optuna",
+    "pandas",
+    "scikit-learn",
+    "scipy",
+    "torch>=1.0.0",
+    "yahpo_gym @ git+https://github.com/slds-lmu/yahpo_gym#egg=yahpo_gym&subdirectory=yahpo_gym",
+]
+
+[project.urls]
+Homepage = "https://github.com/slds-lmu/yahpo_gym"
+
+[tool.ruff]
+line-length = 200
+include = ["pyproject.toml", "yahpo_train/*.py"]
+indent-width = 4
+target-version = "py310"
+fix = true
+unsafe-fixes = true
+
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "PLC", "PLE", "PLW", "I"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.isort]
+profile = "black"

--- a/yahpo_train/yahpo_train/cont_embeddings.py
+++ b/yahpo_train/yahpo_train/cont_embeddings.py
@@ -1,0 +1,147 @@
+# PLR Embeddings from https://github.com/yandex-research/rtdl-num-embeddings/ available via Apache 2.0 LICENSE
+import math
+from typing import Union
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn.parameter import Parameter
+
+
+class _Periodic(nn.Module):
+    """
+    WARNING: the direct usage of this module is discouraged
+    (do this only if you understand why this warning is here).
+    """
+
+    def __init__(self, n_features: int, k: int, sigma: float) -> None:
+        if sigma <= 0.0:
+            raise ValueError(f"sigma must be positive, however: {sigma=}")
+
+        super().__init__()
+        self._sigma = sigma
+        self.weight = Parameter(torch.empty(n_features, k))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        # NOTE[DIFF]
+        # Here, extreme values (~0.3% probability) are explicitly avoided just in case.
+        # In the paper, there was no protection from extreme values.
+        bound = self._sigma * 3
+        nn.init.trunc_normal_(self.weight, 0.0, self._sigma, a=-bound, b=bound)
+
+    def forward(self, x: Tensor) -> Tensor:
+        if x.ndim < 2:
+            raise ValueError(
+                f"The input must have at least two dimensions, however: {x.ndim=}"
+            )
+
+        x = 2 * math.pi * self.weight * x[..., None]
+        x = torch.cat([torch.cos(x), torch.sin(x)], -1)
+        return x
+
+
+# _NLinear is a simplified copy of delu.nn.NLinear:
+# https://yura52.github.io/delu/stable/api/generated/delu.nn.NLinear.html
+class _NLinear(nn.Module):
+    """N *separate* linear layers for N feature embeddings."""
+
+    def __init__(self, n: int, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.weight = Parameter(torch.empty(n, in_features, out_features))
+        self.bias = Parameter(torch.empty(n, out_features))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        d_in_rsqrt = self.weight.shape[-2] ** -0.5
+        nn.init.uniform_(self.weight, -d_in_rsqrt, d_in_rsqrt)
+        nn.init.uniform_(self.bias, -d_in_rsqrt, d_in_rsqrt)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        assert x.ndim == 3
+        assert x.shape[-(self.weight.ndim - 1) :] == self.weight.shape[:-1]
+        x = (x[..., None, :] @ self.weight).squeeze(-2)
+        x = x + self.bias
+        return x
+
+
+class PeriodicEmbeddings(nn.Module):
+    """PL & PLR & PLR(lite) (P ~ Periodic, L ~ Linear, R ~ ReLU) embeddings for continuous features.
+
+    **Shape**
+
+    - Input: `(*, n_features)`
+    - Output: `(*, n_features, d_embedding)`
+
+    **Examples**
+
+    >>> batch_size = 2
+    >>> n_cont_features = 3
+    >>> x = torch.randn(batch_size, n_cont_features)
+    >>>
+    >>> # PLR embeddings (by default, d_embedding=24).
+    >>> m = PeriodicEmbeddings(n_cont_features, lite=False)
+    >>> m(x).shape
+    torch.Size([2, 3, 24])
+    >>>
+    >>> # PLR(lite) embeddings.
+    >>> m = PeriodicEmbeddings(n_cont_features, lite=True)
+    >>> m(x).shape
+    torch.Size([2, 3, 24])
+    >>>
+    >>> # PL embeddings.
+    >>> m = PeriodicEmbeddings(n_cont_features, d_embedding=8, activation=False, lite=False)
+    >>> m(x).shape
+    torch.Size([2, 3, 8])
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        n_features: int,
+        d_embedding: int = 24,
+        *,
+        n_frequencies: int = 48,
+        frequency_init_scale: float = 0.01,
+        activation: bool = True,
+        lite: bool,
+    ) -> None:
+        """
+        Args:
+            n_features: the number of features.
+            d_embedding: the embedding size.
+            n_frequencies: the number of frequencies for each feature.
+                (denoted as "k" in Section 3.3 in the paper).
+            frequency_init_scale: the initialization scale for the first linear layer
+                (denoted as "sigma" in Section 3.3 in the paper).
+                **This is an important hyperparameter**,
+                see the documentation for details.
+            activation: if True, the embeddings is PLR, otherwise, it is PL.
+            lite: if True, the last linear layer (the "L" step)
+                is shared between all features. See the README.md document for details.
+        """
+        super().__init__()
+        self.periodic = _Periodic(n_features, n_frequencies, frequency_init_scale)
+        self.linear: Union[nn.Linear, _NLinear]
+        if lite:
+            # NOTE[DIFF]
+            # The PLR(lite) variation was not covered in this paper about embeddings,
+            # but it was used in the paper about the TabR model.
+            if not activation:
+                raise ValueError("lite=True is allowed only when activation=True")
+            self.linear = nn.Linear(2 * n_frequencies, d_embedding)
+        else:
+            self.linear = _NLinear(n_features, 2 * n_frequencies, d_embedding)
+        self.activation = nn.ReLU() if activation else None
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Do the forward pass."""
+        if x.ndim < 2:
+            raise ValueError(
+                f"The input must have at least two dimensions, however: {x.ndim=}"
+            )
+
+        x = self.periodic(x)
+        x = self.linear(x)
+        if self.activation is not None:
+            x = self.activation(x)
+        return x

--- a/yahpo_train/yahpo_train/cont_scalers.py
+++ b/yahpo_train/yahpo_train/cont_scalers.py
@@ -45,7 +45,7 @@ class ContTransformerRange(nn.Module):
         x: torch.Tensor,
         eps: float = 1e-2,
         x_range: str = "0-1",
-        group: Optional[torch.Tensor] = None,
+        group: torch.Tensor|None = None,
     ):
         super().__init__()
         self.eps = eps

--- a/yahpo_train/yahpo_train/helpers.py
+++ b/yahpo_train/yahpo_train/helpers.py
@@ -1,11 +1,12 @@
-from typing import Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 import torch
 from yahpo_gym import benchmark_set
 
-from yahpo_train.metrics import *
+from yahpo_train.metrics import mae, pearson, r2, spearman
 
 
 def chunk(n: int, size: int) -> List[List[int]]:

--- a/yahpo_train/yahpo_train/learner.py
+++ b/yahpo_train/yahpo_train/learner.py
@@ -1,11 +1,18 @@
 import gc
 import random
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import torch
-from fastai.tabular.all import *
+from fastai.tabular.all import (
+    CancelStepException,
+    Categorify,
+    FillMissing,
+    FillStrategy,
+    df_shrink,
+)
 from fastai.tabular.data import TabularDataLoaders
 from pandas.core.frame import DataFrame
 from yahpo_gym.configuration import Configuration

--- a/yahpo_train/yahpo_train/learner.py
+++ b/yahpo_train/yahpo_train/learner.py
@@ -1,4 +1,5 @@
 import gc
+import json
 import random
 from pathlib import Path
 from typing import Optional, Tuple
@@ -11,6 +12,7 @@ from fastai.tabular.all import (
     Categorify,
     FillMissing,
     FillStrategy,
+    Learner,
     df_shrink,
 )
 from fastai.tabular.data import TabularDataLoaders
@@ -63,13 +65,6 @@ def dl_from_config(
     df = df.sample(frac=1.00, random_state=seed)
 
     gc.collect()
-
-    # df = pd.read_csv(
-    #    config.get_path("dataset"),
-    #    skipinitialspace=skipinitialspace,
-    #    usecols=list(dtypes.keys()),
-    #    dtype=dtypes,
-    # ).sample(frac=1.0, random_state=seed)
 
     # get rid of irrelevant columns
     # if config.instance_names is not None we can be sure that it is the first element of config.cat_names

--- a/yahpo_train/yahpo_train/metrics.py
+++ b/yahpo_train/yahpo_train/metrics.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import numpy as np
 import torch
-from fastai.tabular.all import Metric
+from fastai.tabular.all import Metric, find_bs
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 

--- a/yahpo_train/yahpo_train/metrics.py
+++ b/yahpo_train/yahpo_train/metrics.py
@@ -1,5 +1,8 @@
-import pandas as pd
-from fastai.tabular.all import *
+from typing import Callable
+
+import numpy as np
+import torch
+from fastai.tabular.all import Metric
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 

--- a/yahpo_train/yahpo_train/models.py
+++ b/yahpo_train/yahpo_train/models.py
@@ -8,7 +8,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as nn_init
-from fastai.tabular.all import *
 from fastai.tabular.all import Embedding, get_emb_sz
 from fastai.tabular.data import TabularDataLoaders
 from yahpo_gym.configuration import Configuration
@@ -18,7 +17,6 @@ from yahpo_train.cont_scalers import (
     ContTransformerRangeExtended,
     ContTransformerRangeGrouped,
 )
-from yahpo_train.cont_embeddings import PeriodicEmbeddings
 from yahpo_train.models_utils import get_activation_fn, get_nonglu_activation_fn
 
 

--- a/yahpo_train/yahpo_train/models_ensemble.py
+++ b/yahpo_train/yahpo_train/models_ensemble.py
@@ -1,8 +1,9 @@
-from typing import Callable, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 
+import torch
 from fastai.callback.core import Callback
 from fastai.tabular.data import TabularDataLoaders
-from torch.nn import Module, ModuleList
+from torch.nn import ModuleList
 
 from yahpo_train.learner import SurrogateTabularLearner
 from yahpo_train.models import AbstractSurrogate
@@ -158,7 +159,6 @@ class SurrogateEnsembleLearner(SurrogateTabularLearner):
 
 
 if __name__ == "__main__":
-    from yahpo_gym.benchmarks import iaml
     from yahpo_gym.configuration import cfg
 
     from yahpo_train.learner import SurrogateTabularLearner, dl_from_config

--- a/yahpo_train/yahpo_train/models_ensemble.py
+++ b/yahpo_train/yahpo_train/models_ensemble.py
@@ -6,6 +6,7 @@ from fastai.tabular.data import TabularDataLoaders
 from torch.nn import ModuleList
 
 from yahpo_train.learner import SurrogateTabularLearner
+from yahpo_train.losses import MultiMseLoss
 from yahpo_train.models import AbstractSurrogate
 
 
@@ -161,7 +162,6 @@ if __name__ == "__main__":
     from yahpo_gym.configuration import cfg
 
     from yahpo_train.learner import SurrogateTabularLearner, dl_from_config
-    from yahpo_train.losses import *
     from yahpo_train.models import ResNet
 
     device = torch.device("cpu")

--- a/yahpo_train/yahpo_train/models_ensemble.py
+++ b/yahpo_train/yahpo_train/models_ensemble.py
@@ -7,7 +7,6 @@ from torch.nn import ModuleList
 
 from yahpo_train.learner import SurrogateTabularLearner
 from yahpo_train.models import AbstractSurrogate
-from yahpo_train.models_utils import *
 
 
 def sample_from_simplex(n: int, device: torch.device) -> torch.Tensor:

--- a/yahpo_train/yahpo_train/models_utils.py
+++ b/yahpo_train/yahpo_train/models_utils.py
@@ -1,10 +1,10 @@
+from typing import Callable, Dict, List, Tuple
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.onnx
-from typing import Callable
-from fastai.tabular.all import *
-from fastai.torch_basics import *
+from fastai.tabular.all import TabularPandas, ifnone
 
 
 # Repurposed and adapted from https://github.com/yandex-research/rtdl under Apache License 2.0
@@ -87,7 +87,7 @@ def emb_sz_rule(n_cat: int) -> int:
 
 
 def _one_emb_sz(
-    classes: Dict[str, List[str]], n: str, sz_dict: Optional[Dict] = None
+    classes: Dict[str, List[str]], n: str, sz_dict: Dict | None = None
 ) -> Tuple[int, int]:
     """
     Pick an embedding size for `n` depending on `classes` if not given in `sz_dict`.
@@ -99,7 +99,7 @@ def _one_emb_sz(
 
 
 def get_emb_sz(
-    to: TabularPandas, sz_dict: Optional[Dict[str, int]] = None
+    to: TabularPandas, sz_dict: Dict[str, int] | None = None
 ) -> List[Tuple[int, int]]:
     """
     Get default embedding size from `TabularPreprocessor` `proc` or the ones in `sz_dict`.

--- a/yahpo_train/yahpo_train/models_utils.py
+++ b/yahpo_train/yahpo_train/models_utils.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.onnx
+from typing import Callable
 from fastai.tabular.all import *
 from fastai.torch_basics import *
 
@@ -49,33 +50,31 @@ class GeGLU(nn.Module):
         return geglu(x)
 
 
-def get_activation_fn(name: str) -> typing.Callable[[torch.Tensor], torch.Tensor]:
+def get_activation_fn(name: str) -> Callable[[torch.Tensor], torch.Tensor]:
     """
     Get activation function by name.
     """
     return (
         reglu
         if name == "reglu"
-        else geglu
-        if name == "geglu"
-        else torch.sigmoid
-        if name == "sigmoid"
-        else getattr(F, name)
+        else (
+            geglu
+            if name == "geglu"
+            else torch.sigmoid if name == "sigmoid" else getattr(F, name)
+        )
     )
 
 
 def get_nonglu_activation_fn(
     name: str,
-) -> typing.Callable[[torch.Tensor], torch.Tensor]:
+) -> Callable[[torch.Tensor], torch.Tensor]:
     """
     Get activation function by name.
     """
     return (
         F.relu
         if name == "reglu"
-        else F.gelu
-        if name == "geglu"
-        else get_activation_fn(name)
+        else F.gelu if name == "geglu" else get_activation_fn(name)
     )
 
 


### PR DESCRIPTION
This is a PR that does a bunch of things leading to a massive diff:

### Done 
- [x]  Introduces `pyproject.toml`
- [x] Introduces configs for `ruff, black, isort`. 
- [x] Start making the packages compatible  with linters and formaters
- [x] Introduces the numerical embeddings
- [x] Make everything compatible with ruff, black, isort
- [x] Implement the numerical embeddings for the models, add to tuning space
- [x] Resolve `*` imports


### Out of scope
- [x] Refactor Embeddings into subclass
- [x] Move to PEP 604 (https://peps.python.org/pep-0604/)
- [x] Update to Python >=3.10s
- [x] Pydantic configs?
